### PR TITLE
Call constructor without calibration check

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,16 +183,6 @@ to stand in the `isaac/sdk` folder to launch the application.
 4. Follow [Nvidias guide](https://docs.nvidia.com/isaac/isaac/doc/tutorials/building_apps.html)
  to build your own applications.
 
-When running any of the applications above you will see the following error message
-in the terminal.
-
-```bash
-2021-04-29 13:07:32.825 ERROR packages/universal_robots/ur_client_library/src/ur/calibration_checker.cpp@50: "The calibration parameters of the connected robot don't match the ones from the given kinematics config file. Please be aware that this can lead to critical inaccuracies of tcp positions. Use the ur_calibration tool to extract the correct calibration from the robot and pass that into the description. See [https://github.com/UniversalRobots/Universal_Robots_ROS_Driver#extract-calibration-information] for details".
-```
-
-This error message should just be ignored as the calibration feature is not implemented
-in the Isaac driver. The driver works perfectly fine despite this error message.
-
 Once any of the applications are running you can start the robot program with loaded
 URCap. From that moment on the robot is fully functional. You can make use of the
 Pause function or even Stop the program. Simply press the Play button

--- a/ur_robot_driver/UniversalRobots.cpp
+++ b/ur_robot_driver/UniversalRobots.cpp
@@ -126,15 +126,13 @@ void UniversalRobots::start()
   }
 
   // Set up driver
-  static const bool HEADLESS_MODE = get_headless_mode();
-  static const std::string CALIB_CHECKSUM = "";
   LOG_INFO("Initializing ur driver");
   try
   {
     ur_driver_.reset(new urcl::UrDriver(
         get_robot_ip(), get_control_script_program(), get_rtde_output_recipe(), get_rtde_input_recipe(),
-        std::bind(&UniversalRobots::handle_program_state, this, std::placeholders::_1), HEADLESS_MODE, NULL,
-        CALIB_CHECKSUM, 50001, 50002, get_servoj_gain(), get_servoj_lookahead_time(), false));
+        std::bind(&UniversalRobots::handle_program_state, this, std::placeholders::_1), get_headless_mode(),
+        std::unique_ptr<urcl::ToolCommSetup>{}, 50001, 50002, get_servoj_gain(), get_servoj_lookahead_time(), false));
   }
   catch (urcl::UrException& e)
   {

--- a/ur_robot_driver/doc/sample_applications.md
+++ b/ur_robot_driver/doc/sample_applications.md
@@ -4,16 +4,6 @@ This tutorial explains how to start the sample applications. Before launching an
 application make sure you are placed inside the `isaac/sdk` folder, see [Nvidias
 documentation](https://docs.nvidia.com/isaac/isaac/doc/getting_started.html).
 
-When running any of the below applications you will see
-the following error message in the terminal.
-
-```bash
-2021-04-29 13:07:32.825 ERROR packages/universal_robots/ur_client_library/src/ur/calibration_checker.cpp@50: "The calibration parameters of the connected robot don't match the ones from the given kinematics config file. Please be aware that this can lead to critical inaccuracies of tcp positions. Use the ur_calibration tool to extract the correct calibration from the robot and pass that into the description. See [https://github.com/UniversalRobots/Universal_Robots_ROS_Driver#extract-calibration-information] for details".
-```
-
-This error message should just be ignored as the calibration feature is not implemented
-in the Isaac driver. The driver works perfectly fine despite this error message.
-
 ## Polyscope
 
 Start by preparing the robot for external control. If you are planning on using


### PR DESCRIPTION
This uses the changes introduced in UniversalRobots/Universal_Robots_Client_Library#65

This should be merged once the changes has been merged to the boost branch in the client library. 