### PR TITLE
Don't call stopControl, when stopping application

### DIFF
--- a/ur_robot_driver/UniversalRobots.cpp
+++ b/ur_robot_driver/UniversalRobots.cpp
@@ -256,7 +256,6 @@ void UniversalRobots::stop()
   {
     node()->app()->backend()->node_backend()->stopNode(dashboard_client_);
   }
-  ur_driver_->stopControl();
   rtde_thread_running_ = false;
   rtde_main_loop_trd_.join();
   ur_driver_.reset();


### PR DESCRIPTION
Once in a while the driver crashes when stopping the application, this seems to fix the issue and the driver no longer crashes. 